### PR TITLE
enforce IMDSv2 and restore lb deletion protection defaults

### DIFF
--- a/examples/apigateway/main.tf
+++ b/examples/apigateway/main.tf
@@ -28,8 +28,6 @@ module "wallarm" {
 
   host  = var.host
   token = var.token
-
-  lb_deletion_protection = false
 }
 
 output "suboutputs" {

--- a/examples/from-scratch/main.tf
+++ b/examples/from-scratch/main.tf
@@ -75,8 +75,6 @@ module "wallarm" {
 
   host  = var.host
   token = var.token
-
-  lb_deletion_protection = false
 }
 
 output "suboutputs" {

--- a/examples/proxy/main.tf
+++ b/examples/proxy/main.tf
@@ -36,8 +36,6 @@ module "wallarm" {
   host  = var.host
   token = var.token
 
-  lb_deletion_protection = false
-
   depends_on = [
     aws_acm_certificate_validation.default,
   ]

--- a/modules/template/main.tf
+++ b/modules/template/main.tf
@@ -28,6 +28,10 @@ resource "aws_launch_template" "default" {
     enabled = true
   }
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   disable_api_termination              = true
   instance_initiated_shutdown_behavior = "terminate"
 


### PR DESCRIPTION
## Summary

- Added `metadata_options { http_tokens = "required" }` to the `aws_launch_template`
  in `modules/template/main.tf`, enforcing IMDSv2 for all instances and blocking IMDSv1.
- Removed explicit `lb_deletion_protection = false` overrides from `examples/apigateway`,
  `examples/from-scratch`, and `examples/proxy`, which were overriding the module's
  production-safe default of `true`.

## Why

IMDSv1 is vulnerable to SSRF-based credential theft. The examples, often used as
copy-paste starting points, were silently disabling load balancer deletion protection —
a footgun for production deployments.
